### PR TITLE
Get robot ip only when local API is enabled

### DIFF
--- a/routes/api.js
+++ b/routes/api.js
@@ -23,7 +23,7 @@ if (!blid || !password) {
 
 var myRobot = {};
 
-var handleIP = robotIP ? function (cb) { cb(null, robotIP); } : dorita980.getRobotIP;
+var handleIP = (robotIP || enableLocal === 'no') ? function (cb) { cb(null, robotIP); } : dorita980.getRobotIP;
 handleIP(function (e, ip) {
   if (e) throw e;
   knownIP = ip;


### PR DESCRIPTION
When no ROBOT_IP passed and there is no local roomba, it will show "Connection with robot not ready" even when cloud API is used.
This PR fixes it!