### PR TITLE
Allow passing of additional arguments to actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ Available actions:
 - pause
 - dock
 - resume
+- cleanRoom
 
 Example: start to clean
 
@@ -101,6 +102,20 @@ Success Response:
 ```
 {"ok":null,"id":23}
 ```
+
+Example: clean a specific room
+
+Some roomba types support "room specificic cleaning" - at the time of writing, at least the s9 and the i7 support this featrue. Assuming you have this model, and have a "Smart Map" for the floor you're trying to clean, you can send room specific cleaning commands. The easiest way to find out the values for this is to start a room specific clean via the app, and then look at the `state` endpoint (documented below) and find the `lastCommand` entry. Using this, you can find the room ids. These seem to be stable over time, unless a re-training or new smart map is saved.
+
+The `pmap_id` and `user_pmapv_id` are also derived from the same `lastCommand` trick. These also seem to be stable - unless a new training run or edit to the smart map happens. It's important to get these correct, else your roomba won't clean.
+
+
+```sh
+curl -X POST http://192.168.1.110:3000/api/local/action/cleanRoom -H 'Content-Type: application/json' -d '{"ordered": 0, "pmap_id": "123456", "regions": [{"region_id":"5", "region_name":"Hallway","region_type":"hallway"}], "user_pmapv_id": "987654"}'
+```
+
+> Note that this is a `POST` becuase it has a body, unlike the other related `action` methods.
+
 
 ### Info
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rest980",
-  "version": "2.0.8",
+  "version": "2.1.0",
   "description": "dorita980 REST interface to control your iRobot Roomba 980",
   "private": true,
   "scripts": {

--- a/routes/api.js
+++ b/routes/api.js
@@ -58,7 +58,7 @@ router.get('/local/action/pause', map2dorita('local', 'pause'));
 router.get('/local/action/dock', map2dorita('local', 'dock'));
 router.get('/local/action/resume', map2dorita('local', 'resume'));
 
-router.post('/local/action/cleanRoom', map2dorita('local', 'start', true));
+router.post('/local/action/cleanRoom', map2dorita('local', 'cleanRoom', true));
 
 router.get('/local/config/time', map2dorita('local', 'getTime'));
 router.post('/local/config/time', map2dorita('local', 'setTime', true));

--- a/routes/api.js
+++ b/routes/api.js
@@ -58,6 +58,13 @@ router.get('/local/action/pause', map2dorita('local', 'pause'));
 router.get('/local/action/dock', map2dorita('local', 'dock'));
 router.get('/local/action/resume', map2dorita('local', 'resume'));
 
+
+router.post('/local/action/start', map2dorita('local', 'start'));
+router.post('/local/action/stop', map2dorita('local', 'stop'));
+router.post('/local/action/pause', map2dorita('local', 'pause'));
+router.post('/local/action/dock', map2dorita('local', 'dock'));
+router.post('/local/action/resume', map2dorita('local', 'resume'));
+
 router.get('/local/config/time', map2dorita('local', 'getTime'));
 router.post('/local/config/time', map2dorita('local', 'setTime', true));
 
@@ -142,11 +149,11 @@ function map2dorita (source, method, hasArgs) {
     if (hasArgs) {
       if (!req.body) return next('Invalid arguments.');
     }
+    var hasBody = req.body.constructor === Object && Object.keys(req.body).length > 0;
 
     if (keepAlive === 'no' && firmwareVersion === 2) {
-      return sendAndDisconnect(method, hasArgs ? req.body : undefined, res, next);
+      return sendAndDisconnect(method, hasArgs || hasBody ? req.body : undefined, res, next);
     }
-    var hasBody = req.body.constructor === Object && Object.keys(req.body).length > 0;
     myRobot[source][method](hasArgs || hasBody ? req.body : undefined).then(function (resp) {
       res.send(resp);
     }).catch(next);

--- a/routes/api.js
+++ b/routes/api.js
@@ -58,12 +58,7 @@ router.get('/local/action/pause', map2dorita('local', 'pause'));
 router.get('/local/action/dock', map2dorita('local', 'dock'));
 router.get('/local/action/resume', map2dorita('local', 'resume'));
 
-
-router.post('/local/action/start', map2dorita('local', 'start'));
-router.post('/local/action/stop', map2dorita('local', 'stop'));
-router.post('/local/action/pause', map2dorita('local', 'pause'));
-router.post('/local/action/dock', map2dorita('local', 'dock'));
-router.post('/local/action/resume', map2dorita('local', 'resume'));
+router.post('/local/action/cleanRoom', map2dorita('local', 'start', true));
 
 router.get('/local/config/time', map2dorita('local', 'getTime'));
 router.post('/local/config/time', map2dorita('local', 'setTime', true));
@@ -149,13 +144,11 @@ function map2dorita (source, method, hasArgs) {
     if (hasArgs) {
       if (!req.body) return next('Invalid arguments.');
     }
-    var hasBody = req.body !== undefined
-    console.log(`HasBody was ${hasBody}`);
 
     if (keepAlive === 'no' && firmwareVersion === 2) {
-      return sendAndDisconnect(method, hasArgs || hasBody ? req.body : undefined, res, next);
+      return sendAndDisconnect(method, hasArgs ? req.body : undefined, res, next);
     }
-    myRobot[source][method](hasArgs || hasBody ? req.body : undefined).then(function (resp) {
+    myRobot[source][method](hasArgs ? req.body : undefined).then(function (resp) {
       res.send(resp);
     }).catch(next);
   };

--- a/routes/api.js
+++ b/routes/api.js
@@ -149,7 +149,8 @@ function map2dorita (source, method, hasArgs) {
     if (hasArgs) {
       if (!req.body) return next('Invalid arguments.');
     }
-    var hasBody = req.body.constructor === Object && Object.keys(req.body).length > 0;
+    var hasBody = req.body !== undefined
+    console.log(`HasBody was ${hasBody}`);
 
     if (keepAlive === 'no' && firmwareVersion === 2) {
       return sendAndDisconnect(method, hasArgs || hasBody ? req.body : undefined, res, next);

--- a/routes/api.js
+++ b/routes/api.js
@@ -146,7 +146,8 @@ function map2dorita (source, method, hasArgs) {
     if (keepAlive === 'no' && firmwareVersion === 2) {
       return sendAndDisconnect(method, hasArgs ? req.body : undefined, res, next);
     }
-    myRobot[source][method](hasArgs ? req.body : undefined).then(function (resp) {
+    var hasBody = req.body.constructor === Object && Object.keys(req.body).length > 0;
+    myRobot[source][method](hasArgs || hasBody ? req.body : undefined).then(function (resp) {
       res.send(resp);
     }).catch(next);
   };

--- a/routes/index.js
+++ b/routes/index.js
@@ -5,6 +5,8 @@ var helloResponse = {
   documentation: 'https://github.com/koalazak/rest980'
 };
 
+router.use(express.json());
+
 router.get('/', function (req, res) {
   helloResponse.pong = new Date();
   res.send(helloResponse);


### PR DESCRIPTION
This change is a follow on from the dorita980 change - this allows users to use the rest API to start a room specific cleaning.

This is done by accepting POST requests for actions, and attempting to pass req.body (as json) if present to the underlying call to dorita. 

Tested by starting a room specific cleaning by the API locally :)