### PR TITLE
Added port to docker run command in README. Add easy to use script fo…

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ docker pull koalazak/rest980
 
 Run Docker image:
 ```
-docker run -e BLID=myuser -e PASSWORD=mypass -e ROBOT_IP=myrobotIP koalazak/rest980
+docker run -p 3000:3000 -e BLID=myuser -e PASSWORD=mypass -e ROBOT_IP=myrobotIP koalazak/rest980
 ```
 
 ## Dockerfile
@@ -65,6 +65,16 @@ Also you can local build and test in Docker from this [Dockerfile](https://githu
 
 ```
 docker build . -t koalazak/rest980 
+```
+
+You can also use bash script for automatic build (image) and create of the container by invoking the command.
+You will be prompted about PORT, BLID, PASSWORD and ROBOT_IP.
+If you do not want to be prompted, rather have this script for your own and simply run it, edit it and set thouse variables in Configuration part.
+I would strongly suggest to edit also "config/default.json" with your iRobot parameters. That way it will be copied to container during build.
+
+```
+chmod +x dockerCreate.sh # If no privilages messagee appears
+./dockerCreate.sh
 ```
 
 ## API documentation

--- a/dockerCreate.sh
+++ b/dockerCreate.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+# Script variables
+DOCKER="sudo docker"
+D_BUILD="$DOCKER build"
+D_CONT="$DOCKER container"
+D_CREATE="$DOCKER create"
+
+# Configuration part
+PORT=""
+BLID=""
+PASSWORD=""
+ROBOT_IP=""
+
+RET_VAL=""
+read_if_empty()
+{
+	if [ -z "${!1}" ] ; then
+		echo "Insert values for $1"
+		read
+		RET_VAL="${REPLY}"
+		return
+	fi
+
+	RET_VAL="${!1}"
+}
+read_if_empty PORT
+PORT=$RET_VAL
+read_if_empty BLID
+BLID=$RET_VAL
+read_if_empty PASSWORD
+PASSWORD=$RET_VAL
+read_if_empty ROBOT_IP
+ROBOT_IP=$RET_VAL
+
+# Docker environment
+CONT_NAME=rest980
+IMAGE_NAME=koalazak/rest980/local
+
+exists () {
+        $1 ls -a | grep "$2"
+}
+
+$D_BUILD . -t $IMAGE_NAME
+$D_CREATE \
+	--name=$CONT_NAME \
+	-p $PORT:3000 \
+	-e BLID=$BLID \
+	-e PASSWORD=$PASSWORD \
+	-e ROBOT_IP=$ROBOT_IP \
+	--restart always \
+	$IMAGE_NAME
+
+exists "$D_CONT" $CONT_NAME
+if [ 0 -eq $? ] ; then
+        echo "Creating container named: $CONT_NAME succeed."
+        $D_CONT start $CONT_NAME
+else
+        echo "Failed to create container."
+fi
+


### PR DESCRIPTION
As Dockerfile expose only point out that there is port ready to be exposed it is necessary to assign port during container creation.

Added port to docker run command in README.
Added easy to use script for container create from locally builded image.
Describe procedure in README.