### PR TITLE
Update Dockerfile to support j7 Robot

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use latest node
-FROM node:boron
+FROM node:gallium
 
 MAINTAINER koalazak <zak.tux@gmail.com>
 
@@ -28,6 +28,7 @@ ENV KEEP_ALIVE=
 ENV SSL_KEY_FILE=
 ENV SSL_CERT_FILE=
 ENV PORT=3000
+ENV ROBOT_CIPHERS=TLS_AES_256_GCM_SHA384
 
 EXPOSE ${PORT}
 


### PR DESCRIPTION
The j7 / j7+ requires a different cipher to work. Also the version of node (boron/6.x)  doesn't have support for the newer cipher.